### PR TITLE
Clean up workflow

### DIFF
--- a/.github/workflows/s3-deploys-cleanup.yml
+++ b/.github/workflows/s3-deploys-cleanup.yml
@@ -1,0 +1,16 @@
+name: Clean up deployed branches in S3
+on: [delete]
+
+jobs:
+  build:
+    - name: Clean up deployed branches in S3
+      run: |
+        aws s3 rm \
+          --recursive \
+          --region ${{ secrets.AWS_REGION }} \
+          s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ github.event.ref }}
+        # `github.event` is the delete event that triggered the job
+        # and `github.event.ref` is the branch or tag name that was deleted
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Adding one more workflow to remove the folders created in S3. This will only work if the _Automatically delete head branches_ option is toggled on. When a PR closes, the branch is deleted by GitHub, and this action should run, removing the deployed static assets from S3.